### PR TITLE
Feat/expression types

### DIFF
--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -688,6 +688,7 @@ class Column:
             try:
                 return schema[self.expr].dataType
             except KeyError:
+                # pylint: disable=raise-missing-from
                 raise AnalysisException(
                     f"cannot resolve '`{self.expr}`' given input columns: {schema.fields};"
                 )

--- a/pysparkling/sql/column.py
+++ b/pysparkling/sql/column.py
@@ -1,4 +1,4 @@
-from .expressions.expressions import Expression
+from .expressions.expressions import Expression, RegisteredExpressions
 from .expressions.fields import find_position_in_schema
 from .expressions.literals import Literal
 from .expressions.mappers import CaseWhen, StarOperator
@@ -630,7 +630,7 @@ class Column:
             return self.expr.output_fields(schema)
         return [StructField(
             name=self.col_name,
-            dataType=self.data_type,
+            dataType=self.data_type(schema),
             nullable=self.is_nullable
         )]
 
@@ -647,7 +647,6 @@ class Column:
     def initialize(self, partition_index):
         if isinstance(self.expr, Expression):
             self.expr.recursive_initialize(partition_index)
-        return self
 
     def with_pre_evaluation_schema(self, pre_evaluation_schema):
         if isinstance(self.expr, Expression):
@@ -682,11 +681,19 @@ class Column:
 
     __bool__ = __nonzero__
 
-    @property
-    def data_type(self):
-        # pylint: disable=W0511
-        # todo: be more specific
-        return DataType()
+    def data_type(self, schema):
+        if isinstance(self.expr, (Expression, RegisteredExpressions)):
+            return self.expr.data_type(schema)
+        if isinstance(self.expr, str):
+            try:
+                return schema[self.expr].dataType
+            except KeyError:
+                raise AnalysisException(
+                    f"cannot resolve '`{self.expr}`' given input columns: {schema.fields};"
+                )
+        raise AnalysisException(
+            f"cannot resolve '`{self.expr}`' type, expecting str or Expression but got {type(self.expr)};"
+        )
 
     @property
     def is_nullable(self):

--- a/pysparkling/sql/expressions/arrays.py
+++ b/pysparkling/sql/expressions/arrays.py
@@ -119,7 +119,7 @@ class MapFromArraysColumn(Expression):
         )
 
     def data_type(self, schema):
-        if not self.keys:
+        if not isinstance(self.keys, Column) and not self.keys:
             return MapType(keyType=NullType, valueType=NullType)
         return MapType(
             keyType=self.keys[0].data_type(schema),

--- a/pysparkling/sql/expressions/arrays.py
+++ b/pysparkling/sql/expressions/arrays.py
@@ -1,3 +1,4 @@
+from ..types import BooleanType, ArrayType, NullType, MapType, IntegerType, StringType, StructType
 from ..utils import AnalysisException
 from .expressions import BinaryOperation, Expression, UnaryExpression
 
@@ -14,6 +15,9 @@ class ArraysOverlap(BinaryOperation):
         if set1 and set2 and (None in set1 or None in set2):
             return None
         return False
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class ArrayContains(Expression):
@@ -36,6 +40,9 @@ class ArrayContains(Expression):
             self.value
         )
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class ArrayColumn(Expression):
     pretty_name = "array"
@@ -50,6 +57,11 @@ class ArrayColumn(Expression):
     def args(self):
         return self.columns
 
+    def data_type(self, schema):
+        if not self.columns:
+            return ArrayType(elementType=NullType)
+        return ArrayType(elementType=self.columns[0].data_type(schema))
+
 
 class MapColumn(Expression):
     pretty_name = "map"
@@ -57,6 +69,11 @@ class MapColumn(Expression):
     def __init__(self, *columns):
         super().__init__(columns)
         self.columns = columns
+        if len(columns) % 2 != 0:
+            raise AnalysisException(
+                f"Cannot resolve '{self}' due to data type mismatch: "
+                f"map expects a positive even number of arguments."
+            )
         self.keys = columns[::2]
         self.values = columns[1::2]
 
@@ -69,6 +86,14 @@ class MapColumn(Expression):
     def args(self):
         return self.columns
 
+    def data_type(self, schema):
+        if not self.columns:
+            return MapType(keyType=NullType, valueType=NullType)
+        return MapType(
+            keyType=self.keys[0].data_type(schema),
+            valueType=self.values[0].data_type(schema),
+        )
+
 
 class MapFromArraysColumn(Expression):
     pretty_name = "map_from_arrays"
@@ -79,14 +104,26 @@ class MapFromArraysColumn(Expression):
         self.values = values
 
     def eval(self, row, schema):
-        return dict(
-            zip(self.keys.eval(row, schema), self.values.eval(row, schema))
-        )
+        keys = self.keys.eval(row, schema)
+        values = self.values.eval(row, schema)
+        if len(keys) != len(values):
+            raise AnalysisException(
+                f"Error in '{self}':  The key array and value array of MapData must have the same length."
+            )
+        return dict(zip(keys, values))
 
     def args(self):
         return (
             self.keys,
             self.values
+        )
+
+    def data_type(self, schema):
+        if not self.keys:
+            return MapType(keyType=NullType, valueType=NullType)
+        return MapType(
+            keyType=self.keys[0].data_type(schema),
+            valueType=self.values[0].data_type(schema),
         )
 
 
@@ -101,6 +138,9 @@ class Size(UnaryExpression):
             f"{self.column} value should be an array or a map, got {type(column_value)}"
         )
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class ArraySort(UnaryExpression):
     pretty_name = "array_sort"
@@ -108,19 +148,42 @@ class ArraySort(UnaryExpression):
     def eval(self, row, schema):
         return sorted(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return self.column.data_type(schema)
+
 
 class ArrayMin(UnaryExpression):
     pretty_name = "array_min"
 
     def eval(self, row, schema):
-        return min(self.column.eval(row, schema))
+        column_type = self.column.data_type(schema)
+        column_value = self.column.eval(row, schema)
+        if not column_type == ArrayType:
+            raise AnalysisException(
+                f"Cannot resolve '{self}' due to data type mismatch: argument 1 requires array type, "
+                f"however, '{column_value}' is of {column_type} type."
+            )
+        return min(column_value)
+
+    def data_type(self, schema):
+        return self.column.data_type(schema).elementType()
 
 
 class ArrayMax(UnaryExpression):
     pretty_name = "array_max"
 
     def eval(self, row, schema):
-        return max(self.column.eval(row, schema))
+        column_type = self.column.data_type(schema)
+        column_value = self.column.eval(row, schema)
+        if not column_type == ArrayType:
+            raise AnalysisException(
+                f"Cannot resolve '{self}' due to data type mismatch: argument 1 requires array type, "
+                f"however, '{column_value}' is of {column_type} type."
+            )
+        return max(column_value)
+
+    def data_type(self, schema):
+        return self.column.data_type(schema).elementType()
 
 
 class Slice(Expression):
@@ -142,6 +205,9 @@ class Slice(Expression):
             self.length
         )
 
+    def data_type(self, schema):
+        return self.column.data_type(schema)
+
 
 class ArrayRepeat(Expression):
     pretty_name = "array_repeat"
@@ -161,9 +227,12 @@ class ArrayRepeat(Expression):
             self.count
         )
 
+    def data_type(self, schema):
+        return ArrayType(self.col.data_type(schema))
+
 
 class Sequence(Expression):
-    pretty_name = "array_join"
+    pretty_name = "sequence"
 
     def __init__(self, start, stop, step):
         super().__init__(start, stop, step)
@@ -201,6 +270,9 @@ class Sequence(Expression):
             self.step
         )
 
+    def data_type(self, schema):
+        return ArrayType(self.start.data_type(schema))
+
 
 class ArrayJoin(Expression):
     pretty_name = "array_join"
@@ -231,6 +303,9 @@ class ArrayJoin(Expression):
             self.nullReplacement
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class SortArray(Expression):
     pretty_name = "sort_array"
@@ -249,6 +324,9 @@ class SortArray(Expression):
             self.asc
         )
 
+    def data_type(self, schema):
+        return self.col.data_type(schema)
+
 
 class ArraysZip(Expression):
     pretty_name = "arrays_zip"
@@ -259,7 +337,7 @@ class ArraysZip(Expression):
 
     def eval(self, row, schema):
         return [
-            list(combination)
+            {i: v for i, v in enumerate(combination)}
             for combination in zip(
                 *(c.eval(row, schema) for c in self.columns)
             )
@@ -267,6 +345,11 @@ class ArraysZip(Expression):
 
     def args(self):
         return self.columns
+
+    def data_type(self, schema):
+        return ArrayType(StructType([
+            col.data_type(schema) for col in self.columns
+        ]))
 
 
 class Flatten(UnaryExpression):
@@ -278,6 +361,9 @@ class Flatten(UnaryExpression):
             for array in self.column.eval(row, schema)
             for value in array
         ]
+
+    def data_type(self, schema):
+        return self.column.data_type(schema).elementType
 
 
 class ArrayPosition(Expression):
@@ -303,6 +389,9 @@ class ArrayPosition(Expression):
             self.value
         )
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class ElementAt(Expression):
     pretty_name = "element_at"
@@ -324,6 +413,9 @@ class ElementAt(Expression):
             self.extraction
         )
 
+    def data_type(self, schema):
+        return self.col.data_type(schema).elementType
+
 
 class ArrayRemove(Expression):
     pretty_name = "array_remove"
@@ -343,12 +435,18 @@ class ArrayRemove(Expression):
             self.element
         )
 
+    def data_type(self, schema):
+        return self.col.data_type(schema)
+
 
 class ArrayDistinct(UnaryExpression):
     pretty_name = "array_distinct"
 
     def eval(self, row, schema):
         return list(set(self.column.eval(row, schema)))
+
+    def data_type(self, schema):
+        return self.column.data_type(schema)
 
 
 class ArrayIntersect(BinaryOperation):
@@ -357,6 +455,9 @@ class ArrayIntersect(BinaryOperation):
     def eval(self, row, schema):
         return list(set(self.arg1.eval(row, schema)) & set(self.arg2.eval(row, schema)))
 
+    def data_type(self, schema):
+        return self.arg1.data_type(schema)
+
 
 class ArrayUnion(BinaryOperation):
     pretty_name = "array_union"
@@ -364,12 +465,18 @@ class ArrayUnion(BinaryOperation):
     def eval(self, row, schema):
         return list(set(self.arg1.eval(row, schema)) | set(self.arg2.eval(row, schema)))
 
+    def data_type(self, schema):
+        return self.arg1.data_type(schema)
+
 
 class ArrayExcept(BinaryOperation):
     pretty_name = "array_except"
 
     def eval(self, row, schema):
         return list(set(self.arg1.eval(row, schema)) - set(self.arg2.eval(row, schema)))
+
+    def data_type(self, schema):
+        return self.arg1.data_type(schema)
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/arrays.py
+++ b/pysparkling/sql/expressions/arrays.py
@@ -1,4 +1,5 @@
-from ..types import BooleanType, ArrayType, NullType, MapType, IntegerType, StringType, StructType
+from ..column import Column
+from ..types import ArrayType, BooleanType, IntegerType, MapType, NullType, StringType, StructType
 from ..utils import AnalysisException
 from .expressions import BinaryOperation, Expression, UnaryExpression
 
@@ -337,7 +338,7 @@ class ArraysZip(Expression):
 
     def eval(self, row, schema):
         return [
-            {i: v for i, v in enumerate(combination)}
+            dict(enumerate(combination))
             for combination in zip(
                 *(c.eval(row, schema) for c in self.columns)
             )

--- a/pysparkling/sql/expressions/csvs.py
+++ b/pysparkling/sql/expressions/csvs.py
@@ -2,6 +2,7 @@ from ..casts import NO_TIMESTAMP_CONVERSION
 from ..internal_utils.options import Options
 from ..internal_utils.readers.csvreader import csv_record_to_row, CSVReader
 from ..internal_utils.readers.utils import guess_schema_from_strings
+from ..types import StringType
 from ..utils import AnalysisException
 from .expressions import Expression
 
@@ -33,3 +34,6 @@ class SchemaOfCsv(Expression):
 
     def args(self):
         return (self.column,)
+
+    def data_type(self, schema):
+        return StringType()

--- a/pysparkling/sql/expressions/dates.py
+++ b/pysparkling/sql/expressions/dates.py
@@ -5,7 +5,7 @@ import pytz
 
 from ...utils import parse_tz
 from ..casts import get_time_formatter, get_unix_timestamp_parser
-from ..types import DateType, FloatType, TimestampType
+from ..types import DateType, FloatType, TimestampType, IntegerType, DoubleType, StringType, LongType
 from .expressions import Expression, UnaryExpression
 from .operators import Cast
 
@@ -32,6 +32,8 @@ class AddMonths(Expression):
             self.num_months
         )
 
+    def data_type(self, schema):
+        return DateType()
 
 class DateAdd(Expression):
     pretty_name = "date_add"
@@ -51,6 +53,8 @@ class DateAdd(Expression):
             self.num_days
         )
 
+    def data_type(self, schema):
+        return DateType()
 
 class DateSub(Expression):
     pretty_name = "date_sub"
@@ -70,6 +74,9 @@ class DateSub(Expression):
             self.num_days
         )
 
+    def data_type(self, schema):
+        return DateType()
+
 
 class Year(UnaryExpression):
     pretty_name = "year"
@@ -77,12 +84,18 @@ class Year(UnaryExpression):
     def eval(self, row, schema):
         return Cast(self.column, DateType()).eval(row, schema).year
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class Month(UnaryExpression):
     pretty_name = "month"
 
     def eval(self, row, schema):
         return Cast(self.column, DateType()).eval(row, schema).month
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class Quarter(UnaryExpression):
@@ -92,12 +105,18 @@ class Quarter(UnaryExpression):
         month = Cast(self.column, DateType()).eval(row, schema).month
         return 1 + int((month - 1) / 3)
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class Hour(UnaryExpression):
     pretty_name = "hour"
 
     def eval(self, row, schema):
         return Cast(self.column, TimestampType()).eval(row, schema).hour
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class Minute(UnaryExpression):
@@ -106,6 +125,9 @@ class Minute(UnaryExpression):
     def eval(self, row, schema):
         return Cast(self.column, TimestampType()).eval(row, schema).minute
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class Second(UnaryExpression):
     pretty_name = "second"
@@ -113,12 +135,18 @@ class Second(UnaryExpression):
     def eval(self, row, schema):
         return Cast(self.column, TimestampType()).eval(row, schema).second
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class DayOfMonth(UnaryExpression):
     pretty_name = "dayofmonth"
 
     def eval(self, row, schema):
         return Cast(self.column, DateType()).eval(row, schema).day
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class DayOfYear(UnaryExpression):
@@ -129,6 +157,9 @@ class DayOfYear(UnaryExpression):
         day_from_the_first = value - datetime.date(value.year, 1, 1)
         return 1 + day_from_the_first.days
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class LastDay(UnaryExpression):
     pretty_name = "last_day"
@@ -138,12 +169,18 @@ class LastDay(UnaryExpression):
         first_of_next_month = value + relativedelta(months=1, day=1)
         return first_of_next_month - datetime.timedelta(days=1)
 
+    def data_type(self, schema):
+        return DateType()
+
 
 class WeekOfYear(UnaryExpression):
     pretty_name = "weekofyear"
 
     def eval(self, row, schema):
         return Cast(self.column, DateType()).eval(row, schema).isocalendar()[1]
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class DayOfWeek(UnaryExpression):
@@ -152,6 +189,9 @@ class DayOfWeek(UnaryExpression):
     def eval(self, row, schema):
         date = Cast(self.column, DateType()).eval(row, schema)
         return date.isoweekday() + 1 if date.isoweekday() != 7 else 1
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class NextDay(Expression):
@@ -180,6 +220,9 @@ class NextDay(Expression):
             self.column,
             self.day_of_week
         )
+
+    def data_type(self, schema):
+        return DateType()
 
 
 class MonthsBetween(Expression):
@@ -228,6 +271,9 @@ class MonthsBetween(Expression):
             str(self.round_off).lower()
         )
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class DateDiff(Expression):
     pretty_name = "datediff"
@@ -253,6 +299,9 @@ class DateDiff(Expression):
             self.column2
         )
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class FromUnixTime(Expression):
     pretty_name = "from_unixtime"
@@ -272,6 +321,9 @@ class FromUnixTime(Expression):
             self.column,
             self.format
         )
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class DateFormat(Expression):
@@ -293,6 +345,9 @@ class DateFormat(Expression):
             self.format
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class CurrentTimestamp(Expression):
     pretty_name = "current_timestamp"
@@ -311,6 +366,9 @@ class CurrentTimestamp(Expression):
     def args(self):
         return ()
 
+    def data_type(self, schema):
+        return TimestampType()
+
 
 class CurrentDate(Expression):
     pretty_name = "current_date"
@@ -328,6 +386,9 @@ class CurrentDate(Expression):
 
     def args(self):
         return ()
+
+    def data_type(self, schema):
+        return DateType()
 
 
 class UnixTimestamp(Expression):
@@ -348,6 +409,9 @@ class UnixTimestamp(Expression):
             self.column,
             self.format
         )
+
+    def data_type(self, schema):
+        return LongType()
 
 
 class ParseToTimestamp(Expression):
@@ -373,6 +437,9 @@ class ParseToTimestamp(Expression):
             f"'{self.format}'"
         )
 
+    def data_type(self, schema):
+        return TimestampType()
+
 
 class ParseToDate(Expression):
     pretty_name = "to_date"
@@ -397,6 +464,9 @@ class ParseToDate(Expression):
             f"'{self.format}'"
         )
 
+    def data_type(self, schema):
+        return DateType()
+
 
 class TruncDate(Expression):
     pretty_name = "trunc"
@@ -419,6 +489,9 @@ class TruncDate(Expression):
             self.column,
             self.level
         )
+
+    def data_type(self, schema):
+        return DateType()
 
 
 class TruncTimestamp(Expression):
@@ -475,6 +548,9 @@ class TruncTimestamp(Expression):
             self.column
         )
 
+    def data_type(self, schema):
+        return TimestampType()
+
 
 class FromUTCTimestamp(Expression):
     pretty_name = "from_utc_timestamp"
@@ -499,6 +575,9 @@ class FromUTCTimestamp(Expression):
             self.tz
         )
 
+    def data_type(self, schema):
+        return TimestampType()
+
 
 class ToUTCTimestamp(Expression):
     pretty_name = "to_utc_timestamp"
@@ -522,6 +601,9 @@ class ToUTCTimestamp(Expression):
             self.column,
             self.tz
         )
+
+    def data_type(self, schema):
+        return TimestampType()
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/dates.py
+++ b/pysparkling/sql/expressions/dates.py
@@ -5,7 +5,7 @@ import pytz
 
 from ...utils import parse_tz
 from ..casts import get_time_formatter, get_unix_timestamp_parser
-from ..types import DateType, FloatType, TimestampType, IntegerType, DoubleType, StringType, LongType
+from ..types import DateType, DoubleType, FloatType, IntegerType, LongType, StringType, TimestampType
 from .expressions import Expression, UnaryExpression
 from .operators import Cast
 
@@ -35,6 +35,7 @@ class AddMonths(Expression):
     def data_type(self, schema):
         return DateType()
 
+
 class DateAdd(Expression):
     pretty_name = "date_add"
 
@@ -55,6 +56,7 @@ class DateAdd(Expression):
 
     def data_type(self, schema):
         return DateType()
+
 
 class DateSub(Expression):
     pretty_name = "date_sub"

--- a/pysparkling/sql/expressions/explodes.py
+++ b/pysparkling/sql/expressions/explodes.py
@@ -1,4 +1,4 @@
-from ..types import DataType, IntegerType, StructField
+from ..types import DataType, IntegerType, StructField, StructType
 from .expressions import UnaryExpression
 
 
@@ -20,6 +20,9 @@ class Explode(UnaryExpression):
     def __str__(self):
         return "col"
 
+    def data_type(self, schema):
+        return self.column.data_type(schema).elementType
+
 
 class ExplodeOuter(Explode):
     def eval(self, row, schema):
@@ -30,6 +33,9 @@ class ExplodeOuter(Explode):
 
     def __str__(self):
         return "col"
+
+    def data_type(self, schema):
+        return self.column.data_type(schema).elementType
 
 
 class PosExplode(UnaryExpression):
@@ -53,8 +59,11 @@ class PosExplode(UnaryExpression):
     def output_fields(self, schema):
         return [
             StructField("pos", IntegerType(), False),
-            StructField("col", DataType(), False)
+            StructField("col", self.column.data_type(schema).elementType, False)
         ]
+
+    def data_type(self, schema):
+        return StructType(self.output_fields(schema))
 
 
 class PosExplodeOuter(PosExplode):

--- a/pysparkling/sql/expressions/explodes.py
+++ b/pysparkling/sql/expressions/explodes.py
@@ -1,4 +1,4 @@
-from ..types import DataType, IntegerType, StructField, StructType
+from ..types import IntegerType, StructField, StructType
 from .expressions import UnaryExpression
 
 

--- a/pysparkling/sql/expressions/expressions.py
+++ b/pysparkling/sql/expressions/expressions.py
@@ -36,12 +36,11 @@ class Expression(metaclass=RegisteredExpressions):
     def output_fields(self, schema):
         return [StructField(
             name=str(self),
-            dataType=self.data_type,
+            dataType=self.data_type(schema),
             nullable=self.is_nullable
         )]
 
-    @property
-    def data_type(self):
+    def data_type(self, schema):
         # pylint: disable=W0511
         # todo: be more specific
         return DataType()

--- a/pysparkling/sql/expressions/fields.py
+++ b/pysparkling/sql/expressions/fields.py
@@ -20,6 +20,9 @@ class FieldAsExpression(Expression):
     def args(self):
         return (self.field,)
 
+    def data_type(self, schema):
+        return schema[find_position_in_schema(schema, self.field)].dataType
+
 
 def find_position_in_schema(schema, expr):
     if isinstance(expr, str):

--- a/pysparkling/sql/expressions/jsons.py
+++ b/pysparkling/sql/expressions/jsons.py
@@ -1,9 +1,9 @@
 import json
 
-from ..types import StringType
 from ...utils import get_json_encoder
 from ..internal_utils.options import Options
 from ..internal_utils.readers.jsonreader import JSONReader
+from ..types import StringType
 from .expressions import Expression
 
 

--- a/pysparkling/sql/expressions/jsons.py
+++ b/pysparkling/sql/expressions/jsons.py
@@ -1,5 +1,6 @@
 import json
 
+from ..types import StringType
 from ...utils import get_json_encoder
 from ..internal_utils.options import Options
 from ..internal_utils.readers.jsonreader import JSONReader
@@ -36,6 +37,9 @@ class StructsToJson(Expression):
             self.column,
             self.input_options
         )
+
+    def data_type(self, schema):
+        return StringType()
 
 
 __all__ = ["StructsToJson"]

--- a/pysparkling/sql/expressions/literals.py
+++ b/pysparkling/sql/expressions/literals.py
@@ -1,3 +1,4 @@
+from ..types import _infer_type
 from ..utils import AnalysisException
 from .expressions import Expression
 
@@ -6,6 +7,7 @@ class Literal(Expression):
     def __init__(self, value):
         super().__init__()
         self.value = value
+        self._data_type = _infer_type(self.value)
 
     def eval(self, row, schema):
         return self.value
@@ -27,6 +29,9 @@ class Literal(Expression):
 
     def args(self):
         return (self.value, )
+
+    def data_type(self, schema):
+        return self._data_type
 
 
 __all__ = ["Literal"]

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -598,7 +598,7 @@ class Rint(UnaryExpression):
     pretty_name = "ROUND"
 
     def eval(self, row, schema):
-        return round(self.column.eval(row, schema))
+        return float(round(self.column.eval(row, schema)))
 
     def data_type(self, schema):
         return DoubleType()
@@ -745,7 +745,7 @@ class ShiftLeft(Expression):
         self.num_bits = num_bits.get_literal_value()
 
     def eval(self, row, schema):
-        return self.arg.eval(row, schema) << self.num_bits
+        return int(self.arg.eval(row, schema)) << self.num_bits
 
     def args(self):
         return (
@@ -766,7 +766,7 @@ class ShiftRight(Expression):
         self.num_bits = num_bits.get_literal_value()
 
     def eval(self, row, schema):
-        return self.arg.eval(row, schema) >> self.num_bits
+        return int(self.arg.eval(row, schema)) >> self.num_bits
 
     def args(self):
         return (
@@ -787,7 +787,7 @@ class ShiftRightUnsigned(Expression):
         self.num_bits = num_bits.get_literal_value()
 
     def eval(self, row, schema):
-        rightShifted = self.arg.eval(row, schema) >> self.num_bits
+        rightShifted = int(self.arg.eval(row, schema)) >> self.num_bits
         return rightShifted % JVM_MAX_INTEGER_SIZE
 
     def args(self):

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -1238,7 +1238,7 @@ class Grouping(UnaryExpression):
     def eval(self, row, schema):
         metadata = row.get_metadata()
         if metadata is None or "grouping" not in metadata:
-            raise AnalysisException("grouping_id() can only be used with GroupingSets/Cube/Rollup")
+            raise AnalysisException("grouping() can only be used with GroupingSets/Cube/Rollup")
         pos = self.column.find_position_in_schema(schema)
         return int(metadata["grouping"][pos])
 

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -6,7 +6,8 @@ import string
 
 from ...utils import half_even_round, half_up_round, MonotonicallyIncreasingIDGenerator, XORShiftRandom
 from ..internal_utils.column import resolve_column
-from ..types import create_row, StringType
+from ..types import create_row, StringType, NullType, BooleanType, DoubleType, LongType, IntegerType, ArrayType, \
+    StructType, StructField, MapType, BinaryType
 from ..utils import AnalysisException
 from .expressions import Expression, NullSafeColumnOperation, UnaryExpression
 from .operators import Cast
@@ -72,6 +73,9 @@ class CaseWhen(Expression):
             default
         )
 
+    def data_type(self, schema):
+        return self.values[0].data_type(schema)
+
 
 class Otherwise(Expression):
     def __init__(self, conditions, values, default):
@@ -105,6 +109,9 @@ class Otherwise(Expression):
             self.default
         )
 
+    def data_type(self, schema):
+        return self.values[0].data_type(schema)
+
 
 class RegExpExtract(Expression):
     pretty_name = "regexp_extract"
@@ -137,6 +144,9 @@ class RegExpExtract(Expression):
             self.groupIdx
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class RegExpReplace(Expression):
     pretty_name = "regexp_replace"
@@ -161,6 +171,9 @@ class RegExpReplace(Expression):
             self.replacement
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class Round(NullSafeColumnOperation):
     pretty_name = "round"
@@ -178,6 +191,9 @@ class Round(NullSafeColumnOperation):
             self.scale
         )
 
+    def data_type(self, schema):
+        return self.column.data_type(schema)
+
 
 class Bround(NullSafeColumnOperation):
     pretty_name = "bround"
@@ -194,6 +210,9 @@ class Bround(NullSafeColumnOperation):
             self.column,
             self.scale
         )
+
+    def data_type(self, schema):
+        return self.column.data_type(schema)
 
 
 class FormatNumber(Expression):
@@ -219,6 +238,9 @@ class FormatNumber(Expression):
             self.digits
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class SubstringIndex(Expression):
     pretty_name = "substring_index"
@@ -240,6 +262,9 @@ class SubstringIndex(Expression):
             self.count
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class Coalesce(Expression):
     pretty_name = "coalesce"
@@ -258,12 +283,22 @@ class Coalesce(Expression):
     def args(self):
         return self.columns
 
+    def data_type(self, schema):
+        for col in self.columns:
+            col_type = col.data_type(schema)
+            if col_type != NullType():
+                return col_type
+        return NullType()
+
 
 class IsNaN(UnaryExpression):
     pretty_name = "isnan"
 
     def eval(self, row, schema):
         return math.isnan(self.eval(row, schema))
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class NaNvl(Expression):
@@ -287,6 +322,9 @@ class NaNvl(Expression):
             self.col2
         )
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Hypot(Expression):
     pretty_name = "hypot"
@@ -305,12 +343,18 @@ class Hypot(Expression):
             self.b
         )
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Sqrt(UnaryExpression):
     pretty_name = "SQRT"
 
     def eval(self, row, schema):
         return math.sqrt(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Cbrt(UnaryExpression):
@@ -319,12 +363,18 @@ class Cbrt(UnaryExpression):
     def eval(self, row, schema):
         return self.column.eval(row, schema) ** 1. / 3.
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Abs(UnaryExpression):
     pretty_name = "ABS"
 
     def eval(self, row, schema):
         return abs(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return self.column.data_type(schema)
 
 
 class Acos(UnaryExpression):
@@ -333,6 +383,9 @@ class Acos(UnaryExpression):
     def eval(self, row, schema):
         return math.acos(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Asin(UnaryExpression):
     pretty_name = "ASIN"
@@ -340,12 +393,18 @@ class Asin(UnaryExpression):
     def eval(self, row, schema):
         return math.asin(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Atan(UnaryExpression):
     pretty_name = "ATAN"
 
     def eval(self, row, schema):
         return math.atan(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Atan2(Expression):
@@ -365,12 +424,18 @@ class Atan2(Expression):
             self.x
         )
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Tan(UnaryExpression):
     pretty_name = "TAN"
 
     def eval(self, row, schema):
         return math.tan(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Tanh(UnaryExpression):
@@ -379,12 +444,18 @@ class Tanh(UnaryExpression):
     def eval(self, row, schema):
         return math.tanh(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Cos(UnaryExpression):
     pretty_name = "COS"
 
     def eval(self, row, schema):
         return math.cos(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Cosh(UnaryExpression):
@@ -393,12 +464,18 @@ class Cosh(UnaryExpression):
     def eval(self, row, schema):
         return math.cosh(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Sin(UnaryExpression):
     pretty_name = "SIN"
 
     def eval(self, row, schema):
         return math.sin(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Sinh(UnaryExpression):
@@ -407,12 +484,18 @@ class Sinh(UnaryExpression):
     def eval(self, row, schema):
         return math.sinh(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Exp(UnaryExpression):
     pretty_name = "EXP"
 
     def eval(self, row, schema):
         return math.exp(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class ExpM1(UnaryExpression):
@@ -421,12 +504,18 @@ class ExpM1(UnaryExpression):
     def eval(self, row, schema):
         return math.expm1(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Factorial(UnaryExpression):
     pretty_name = "factorial"
 
     def eval(self, row, schema):
         return math.factorial(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return LongType()
 
 
 class Floor(UnaryExpression):
@@ -435,12 +524,18 @@ class Floor(UnaryExpression):
     def eval(self, row, schema):
         return math.floor(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return LongType()
+
 
 class Ceil(UnaryExpression):
     pretty_name = "CEIL"
 
     def eval(self, row, schema):
         return math.ceil(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return LongType()
 
 
 class Log(Expression):
@@ -459,11 +554,14 @@ class Log(Expression):
 
     def args(self):
         if self.base == math.e:
-            return (self.value, )
+            return (self.value,)
         return (
             self.base,
             self.value
         )
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Log10(UnaryExpression):
@@ -472,12 +570,18 @@ class Log10(UnaryExpression):
     def eval(self, row, schema):
         return math.log10(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Log2(UnaryExpression):
     pretty_name = "LOG2"
 
     def eval(self, row, schema):
         return math.log(self.column.eval(row, schema), 2)
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Log1p(UnaryExpression):
@@ -486,12 +590,18 @@ class Log1p(UnaryExpression):
     def eval(self, row, schema):
         return math.log1p(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Rint(UnaryExpression):
     pretty_name = "ROUND"
 
     def eval(self, row, schema):
         return round(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Signum(UnaryExpression):
@@ -505,6 +615,9 @@ class Signum(UnaryExpression):
             return 1.0
         return -1.0
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class ToDegrees(UnaryExpression):
     pretty_name = "DEGREES"
@@ -512,12 +625,18 @@ class ToDegrees(UnaryExpression):
     def eval(self, row, schema):
         return math.degrees(self.column.eval(row, schema))
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class ToRadians(UnaryExpression):
     pretty_name = "RADIANS"
 
     def eval(self, row, schema):
         return math.radians(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        return DoubleType()
 
 
 class Rand(Expression):
@@ -537,6 +656,9 @@ class Rand(Expression):
     def args(self):
         return self.seed
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Randn(Expression):
     pretty_name = "randn"
@@ -555,6 +677,9 @@ class Randn(Expression):
     def args(self):
         return self.seed
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class SparkPartitionID(Expression):
     pretty_name = "SPARK_PARTITION_ID"
@@ -571,6 +696,9 @@ class SparkPartitionID(Expression):
 
     def args(self):
         return ()
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class CreateStruct(Expression):
@@ -591,12 +719,21 @@ class CreateStruct(Expression):
     def args(self):
         return self.columns
 
+    def data_type(self, schema):
+        return StructType([
+            StructField(name=str(col), dataType=col.data_type(schema), nullable=True)
+            for col in self.columns
+        ])
+
 
 class Bin(UnaryExpression):
     pretty_name = "bin"
 
     def eval(self, row, schema):
         return format(self.column.eval(row, schema), 'b')
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class ShiftLeft(Expression):
@@ -616,6 +753,9 @@ class ShiftLeft(Expression):
             self.num_bits
         )
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class ShiftRight(Expression):
     pretty_name = "shiftright"
@@ -633,6 +773,9 @@ class ShiftRight(Expression):
             self.arg,
             self.num_bits
         )
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class ShiftRightUnsigned(Expression):
@@ -653,6 +796,9 @@ class ShiftRightUnsigned(Expression):
             self.num_bits
         )
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class Greatest(Expression):
     pretty_name = "greatest"
@@ -667,6 +813,11 @@ class Greatest(Expression):
 
     def args(self):
         return self.columns
+
+    def data_type(self, schema):
+        if not self.columns:
+            return NullType()
+        return self.columns[0].data_type(schema)
 
 
 class Least(Expression):
@@ -683,12 +834,20 @@ class Least(Expression):
     def args(self):
         return self.columns
 
+    def data_type(self, schema):
+        if not self.columns:
+            return NullType()
+        return self.columns[0].data_type(schema)
+
 
 class Length(UnaryExpression):
     pretty_name = "length"
 
     def eval(self, row, schema):
         return len(str(self.column.eval(row, schema)))
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class Lower(UnaryExpression):
@@ -697,12 +856,18 @@ class Lower(UnaryExpression):
     def eval(self, row, schema):
         return str(self.column.eval(row, schema)).lower()
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class Upper(UnaryExpression):
     pretty_name = "upper"
 
     def eval(self, row, schema):
         return str(self.column.eval(row, schema)).upper()
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class Concat(Expression):
@@ -717,6 +882,9 @@ class Concat(Expression):
 
     def args(self):
         return self.columns
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class ConcatWs(Expression):
@@ -735,12 +903,18 @@ class ConcatWs(Expression):
             return [self.sep] + list(self.columns)
         return [self.sep]
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class Reverse(UnaryExpression):
     pretty_name = "reverse"
 
     def eval(self, row, schema):
         return str(self.column.eval(row, schema))[::-1]
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class MapKeys(UnaryExpression):
@@ -749,12 +923,18 @@ class MapKeys(UnaryExpression):
     def eval(self, row, schema):
         return list(self.column.eval(row, schema).keys())
 
+    def data_type(self, schema):
+        return ArrayType(elementType=self.column.data_type(schema).keyType)
+
 
 class MapValues(UnaryExpression):
     pretty_name = "map_values"
 
     def eval(self, row, schema):
         return list(self.column.eval(row, schema).values())
+
+    def data_type(self, schema):
+        return ArrayType(elementType=self.column.data_type(schema).valueType)
 
 
 class MapEntries(UnaryExpression):
@@ -763,12 +943,24 @@ class MapEntries(UnaryExpression):
     def eval(self, row, schema):
         return list(self.column.eval(row, schema).items())
 
+    def data_type(self, schema):
+        return ArrayType(elementType=self.column.data_type(schema).valueType)
+
 
 class MapFromEntries(UnaryExpression):
     pretty_name = "map_from_entries"
 
     def eval(self, row, schema):
         return dict(self.column.eval(row, schema))
+
+    def data_type(self, schema):
+        map_type = self.column.data_type(schema)
+        key_type = map_type.keyType
+        value_type = map_type.valueType
+        return ArrayType(elementType=StructType([
+            StructField("key", key_type, True),
+            StructField("value", value_type, True),
+        ]))
 
 
 class MapConcat(Expression):
@@ -788,6 +980,11 @@ class MapConcat(Expression):
 
     def args(self):
         return self.columns
+
+    def data_type(self, schema):
+        if not self.columns:
+            return MapType(keyType=StringType(), valueType=StringType)
+        return self.columns[0].data_type(schema)
 
 
 class StringSplit(Expression):
@@ -815,6 +1012,9 @@ class StringSplit(Expression):
             self.regex,
             self.limit
         )
+
+    def data_type(self, schema):
+        return ArrayType(elementType=StringType())
 
 
 class Conv(Expression):
@@ -916,6 +1116,9 @@ class Conv(Expression):
 
         return returned_string
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class Hex(UnaryExpression):
     pretty_name = "hex"
@@ -927,6 +1130,9 @@ class Hex(UnaryExpression):
             to_base=16,
             positive_only=True
         )
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class Unhex(UnaryExpression):
@@ -940,6 +1146,9 @@ class Unhex(UnaryExpression):
             positive_only=True
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class Ascii(UnaryExpression):
     pretty_name = "ascii"
@@ -952,6 +1161,9 @@ class Ascii(UnaryExpression):
         if not value_as_string:
             return None
         return ord(value_as_string[0])
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class MonotonicallyIncreasingID(Expression):
@@ -970,6 +1182,9 @@ class MonotonicallyIncreasingID(Expression):
     def args(self):
         return ()
 
+    def data_type(self, schema):
+        return LongType()
+
 
 class Base64(UnaryExpression):
     pretty_name = "base64"
@@ -979,6 +1194,9 @@ class Base64(UnaryExpression):
         encoded = base64.b64encode(bytes(value, encoding="utf-8"))
         return str(encoded)[2:-1]
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class UnBase64(UnaryExpression):
     pretty_name = "unbase64"
@@ -986,6 +1204,9 @@ class UnBase64(UnaryExpression):
     def eval(self, row, schema):
         value = self.column.eval(row, schema)
         return bytearray(base64.b64decode(value))
+
+    def data_type(self, schema):
+        return BinaryType()
 
 
 class GroupingID(Expression):
@@ -1007,6 +1228,9 @@ class GroupingID(Expression):
     def args(self):
         return self.columns
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class Grouping(UnaryExpression):
     pretty_name = "grouping"
@@ -1017,6 +1241,9 @@ class Grouping(UnaryExpression):
             raise AnalysisException("grouping_id() can only be used with GroupingSets/Cube/Rollup")
         pos = self.column.find_position_in_schema(schema)
         return int(metadata["grouping"][pos])
+
+    def data_type(self, schema):
+        return self.column.data_type(schema)
 
 
 class InputFileName(Expression):
@@ -1030,6 +1257,9 @@ class InputFileName(Expression):
 
     def args(self):
         return ()
+
+    def data_type(self, schema):
+        return StringType()
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/mappers.py
+++ b/pysparkling/sql/expressions/mappers.py
@@ -6,8 +6,10 @@ import string
 
 from ...utils import half_even_round, half_up_round, MonotonicallyIncreasingIDGenerator, XORShiftRandom
 from ..internal_utils.column import resolve_column
-from ..types import create_row, StringType, NullType, BooleanType, DoubleType, LongType, IntegerType, ArrayType, \
-    StructType, StructField, MapType, BinaryType
+from ..types import (
+    ArrayType, BinaryType, BooleanType, create_row, DoubleType, IntegerType, LongType, MapType, NullType, StringType,
+    StructField, StructType
+)
 from ..utils import AnalysisException
 from .expressions import Expression, NullSafeColumnOperation, UnaryExpression
 from .operators import Cast

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,5 +1,5 @@
 from ..casts import get_caster
-from ..types import Row, StructType, DoubleType, BooleanType, StringType, largest_numeric_type
+from ..types import BooleanType, DoubleType, largest_numeric_type, Row, StringType, StructType
 from .expressions import BinaryOperation, Expression, NullSafeBinaryOperation, TypeSafeBinaryOperation, UnaryExpression
 
 

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -292,12 +292,16 @@ class Cast(Expression):
         super().__init__(column)
         self.column = column
         self.destination_type = destination_type
-        self.caster = get_caster(
-            from_type=self.column.data_type, to_type=destination_type, options={}
-        )
 
     def eval(self, row, schema):
-        return self.caster(self.column.eval(row, schema))
+        caster = get_caster(
+            from_type=self.column.data_type(schema),
+            to_type=self.destination_type,
+            options={}
+        )
+        return caster(
+            self.column.eval(row, schema)
+        )
 
     def __str__(self):
         return str(self.column)

--- a/pysparkling/sql/expressions/operators.py
+++ b/pysparkling/sql/expressions/operators.py
@@ -1,5 +1,5 @@
 from ..casts import get_caster
-from ..types import Row, StructType
+from ..types import Row, StructType, DoubleType, BooleanType, StringType, largest_numeric_type
 from .expressions import BinaryOperation, Expression, NullSafeBinaryOperation, TypeSafeBinaryOperation, UnaryExpression
 
 
@@ -10,6 +10,9 @@ class Negate(UnaryExpression):
     def __str__(self):
         return f"(- {self.column})"
 
+    def data_type(self, schema):
+        return self.column.data_type(schema)
+
 
 class Add(NullSafeBinaryOperation):
     def unsafe_operation(self, value1, value2):
@@ -17,6 +20,11 @@ class Add(NullSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} + {self.arg2})"
+
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="add")
 
 
 class Minus(NullSafeBinaryOperation):
@@ -26,6 +34,11 @@ class Minus(NullSafeBinaryOperation):
     def __str__(self):
         return f"({self.arg1} - {self.arg2})"
 
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="minus")
+
 
 class Time(NullSafeBinaryOperation):
     def unsafe_operation(self, value1, value2):
@@ -33,6 +46,11 @@ class Time(NullSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} * {self.arg2})"
+
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="multiply")
 
 
 class Divide(NullSafeBinaryOperation):
@@ -42,6 +60,11 @@ class Divide(NullSafeBinaryOperation):
     def __str__(self):
         return f"({self.arg1} / {self.arg2})"
 
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="divide")
+
 
 class Mod(NullSafeBinaryOperation):
     def unsafe_operation(self, value1, value2):
@@ -49,6 +72,11 @@ class Mod(NullSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} % {self.arg2})"
+
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="mod")
 
 
 class Pow(NullSafeBinaryOperation):
@@ -58,6 +86,9 @@ class Pow(NullSafeBinaryOperation):
     def __str__(self):
         return f"POWER({self.arg1}, {self.arg2})"
 
+    def data_type(self, schema):
+        return DoubleType()
+
 
 class Equal(TypeSafeBinaryOperation):
     def unsafe_operation(self, value_1, value_2):
@@ -65,6 +96,9 @@ class Equal(TypeSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} = {self.arg2})"
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class LessThan(TypeSafeBinaryOperation):
@@ -74,6 +108,9 @@ class LessThan(TypeSafeBinaryOperation):
     def __str__(self):
         return f"({self.arg1} < {self.arg2})"
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class LessThanOrEqual(TypeSafeBinaryOperation):
     def unsafe_operation(self, value_1, value_2):
@@ -81,6 +118,9 @@ class LessThanOrEqual(TypeSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} <= {self.arg2})"
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class GreaterThan(TypeSafeBinaryOperation):
@@ -90,6 +130,9 @@ class GreaterThan(TypeSafeBinaryOperation):
     def __str__(self):
         return f"({self.arg1} > {self.arg2})"
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class GreaterThanOrEqual(TypeSafeBinaryOperation):
     def unsafe_operation(self, value_1, value_2):
@@ -97,6 +140,9 @@ class GreaterThanOrEqual(TypeSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} >= {self.arg2})"
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class And(TypeSafeBinaryOperation):
@@ -106,6 +152,9 @@ class And(TypeSafeBinaryOperation):
     def __str__(self):
         return f"({self.arg1} AND {self.arg2})"
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class Or(TypeSafeBinaryOperation):
     def unsafe_operation(self, value_1, value_2):
@@ -113,6 +162,9 @@ class Or(TypeSafeBinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} OR {self.arg2})"
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class Invert(UnaryExpression):
@@ -125,6 +177,9 @@ class Invert(UnaryExpression):
     def __str__(self):
         return f"(NOT {self.column})"
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class BitwiseOr(BinaryOperation):
     def eval(self, row, schema):
@@ -132,6 +187,11 @@ class BitwiseOr(BinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} | {self.arg2})"
+
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="bitwise_or")
 
 
 class BitwiseAnd(BinaryOperation):
@@ -141,6 +201,11 @@ class BitwiseAnd(BinaryOperation):
     def __str__(self):
         return f"({self.arg1} & {self.arg2})"
 
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="bitwise_and")
+
 
 class BitwiseXor(BinaryOperation):
     def eval(self, row, schema):
@@ -148,6 +213,11 @@ class BitwiseXor(BinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} ^ {self.arg2})"
+
+    def data_type(self, schema):
+        type1 = self.arg1.data_type(schema)
+        type2 = self.arg2.data_type(schema)
+        return largest_numeric_type(type1, type2, operation="bitwise_xor")
 
 
 class BitwiseNot(UnaryExpression):
@@ -157,6 +227,9 @@ class BitwiseNot(UnaryExpression):
     def __str__(self):
         return f"~{self.column}"
 
+    def data_type(self, schema):
+        return self.column.data_type(schema)
+
 
 class EqNullSafe(BinaryOperation):
     def eval(self, row, schema):
@@ -164,6 +237,9 @@ class EqNullSafe(BinaryOperation):
 
     def __str__(self):
         return f"({self.arg1} <=> {self.arg2})"
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class GetField(Expression):
@@ -217,6 +293,9 @@ class Contains(Expression):
             self.value
         )
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class StartsWith(Expression):
     pretty_name = "startswith"
@@ -234,6 +313,9 @@ class StartsWith(Expression):
             self.arg1,
             self.substr
         )
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class EndsWith(Expression):
@@ -253,6 +335,9 @@ class EndsWith(Expression):
             self.substr
         )
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class IsIn(Expression):
     def __init__(self, arg1, cols):
@@ -270,6 +355,9 @@ class IsIn(Expression):
     def args(self):
         return [self.arg1] + self.cols
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class IsNotNull(UnaryExpression):
     def eval(self, row, schema):
@@ -278,6 +366,9 @@ class IsNotNull(UnaryExpression):
     def __str__(self):
         return f"({self.column} IS NOT NULL)"
 
+    def data_type(self, schema):
+        return BooleanType()
+
 
 class IsNull(UnaryExpression):
     def eval(self, row, schema):
@@ -285,6 +376,9 @@ class IsNull(UnaryExpression):
 
     def __str__(self):
         return f"({self.column} IS NULL)"
+
+    def data_type(self, schema):
+        return BooleanType()
 
 
 class Cast(Expression):
@@ -315,6 +409,9 @@ class Cast(Expression):
             self.destination_type
         )
 
+    def data_type(self, schema):
+        return self.destination_type
+
 
 class Substring(Expression):
     pretty_name = "substring"
@@ -334,6 +431,9 @@ class Substring(Expression):
             self.start,
             self.length
         )
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class Alias(Expression):
@@ -366,6 +466,9 @@ class Alias(Expression):
             self.alias
         )
 
+    def data_type(self, schema):
+        return self.expr.data_type(schema)
+
 
 class UnaryPositive(UnaryExpression):
     def eval(self, row, schema):
@@ -373,6 +476,9 @@ class UnaryPositive(UnaryExpression):
 
     def __str__(self):
         return f"(+ {self.column})"
+
+    def data_type(self, schema):
+        return self.column.data_type(schema)
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/orders.py
+++ b/pysparkling/sql/expressions/orders.py
@@ -17,6 +17,9 @@ class SortOrder(Expression):
     def args(self):
         return (self.column,)
 
+    def data_type(self, schema):
+        return self.column.data_type(schema)
+
 
 class AscNullsFirst(SortOrder):
     sort_order = "ASC NULLS FIRST"

--- a/pysparkling/sql/expressions/strings.py
+++ b/pysparkling/sql/expressions/strings.py
@@ -1,7 +1,7 @@
 import string
 
 from ...utils import levenshtein_distance
-from ..types import StringType
+from ..types import StringType, IntegerType
 from .expressions import Expression, UnaryExpression
 from .operators import Cast
 
@@ -12,6 +12,9 @@ class StringTrim(UnaryExpression):
     def eval(self, row, schema):
         return self.column.eval(row, schema).strip()
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class StringLTrim(UnaryExpression):
     pretty_name = "ltrim"
@@ -19,12 +22,18 @@ class StringLTrim(UnaryExpression):
     def eval(self, row, schema):
         return self.column.eval(row, schema).lstrip()
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class StringRTrim(UnaryExpression):
     pretty_name = "rtrim"
 
     def eval(self, row, schema):
         return self.column.eval(row, schema).rstrip()
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class StringInStr(Expression):
@@ -48,6 +57,9 @@ class StringInStr(Expression):
             self.column,
             self.substr
         )
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class StringLocate(Expression):
@@ -77,6 +89,9 @@ class StringLocate(Expression):
             self.start
         )
 
+    def data_type(self, schema):
+        return IntegerType()
+
 
 class StringLPad(Expression):
     pretty_name = "lpad"
@@ -99,6 +114,9 @@ class StringLPad(Expression):
             self.length,
             self.pad
         )
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class StringRPad(Expression):
@@ -123,6 +141,9 @@ class StringRPad(Expression):
             self.pad
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class StringRepeat(Expression):
     pretty_name = "repeat"
@@ -141,6 +162,9 @@ class StringRepeat(Expression):
             self.column,
             self.n
         )
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class StringTranslate(Expression):
@@ -168,6 +192,9 @@ class StringTranslate(Expression):
             self.replace_string
         )
 
+    def data_type(self, schema):
+        return StringType()
+
 
 class InitCap(UnaryExpression):
     pretty_name = "initcap"
@@ -175,6 +202,9 @@ class InitCap(UnaryExpression):
     def eval(self, row, schema):
         value = Cast(self.column, StringType()).eval(row, schema)
         return " ".join(word.capitalize() for word in value.split())
+
+    def data_type(self, schema):
+        return StringType()
 
 
 class Levenshtein(Expression):
@@ -197,6 +227,9 @@ class Levenshtein(Expression):
             self.column1,
             self.column2
         )
+
+    def data_type(self, schema):
+        return IntegerType()
 
 
 class SoundEx(UnaryExpression):
@@ -247,6 +280,9 @@ class SoundEx(UnaryExpression):
         Returns None if the letter is not recognized
         """
         return self._soundex_mapping.get(letter)
+
+    def data_type(self, schema):
+        return StringType()
 
 
 __all__ = [

--- a/pysparkling/sql/expressions/strings.py
+++ b/pysparkling/sql/expressions/strings.py
@@ -1,7 +1,7 @@
 import string
 
 from ...utils import levenshtein_distance
-from ..types import StringType, IntegerType
+from ..types import IntegerType, StringType
 from .expressions import Expression, UnaryExpression
 from .operators import Cast
 

--- a/pysparkling/sql/expressions/userdefined.py
+++ b/pysparkling/sql/expressions/userdefined.py
@@ -18,5 +18,8 @@ class UserDefinedFunction(Expression):
     def args(self):
         return self.exprs
 
+    def data_type(self, schema):
+        return self.return_type
+
 
 __all__ = ["UserDefinedFunction"]

--- a/pysparkling/sql/internals.py
+++ b/pysparkling/sql/internals.py
@@ -358,20 +358,21 @@ class DataFrameInternal:
 
         def select_mapper(partition_index, partition):
             # Initialize non deterministic functions so that they are reproducible
-            initialized_cols = [col.initialize(partition_index) for col in cols]
-            generators = [col for col in initialized_cols if col.may_output_multiple_rows]
-            non_generators = [col for col in initialized_cols if not col.may_output_multiple_rows]
+            for col in cols:
+                col.initialize(partition_index)
+            generators = [col for col in cols if col.may_output_multiple_rows]
+            non_generators = [col for col in cols if not col.may_output_multiple_rows]
             number_of_generators = len(generators)
             if number_of_generators > 1:
                 raise Exception(
                     "Only one generator allowed per select clause"
-                    f" but found {number_of_generators}: {', '.join(generators)}"
+                    f" but found {number_of_generators}: {', '.join(str(g) for g in generators)}"
                 )
 
             return self.get_select_output_field_lists(
                 partition,
                 non_generators,
-                initialized_cols,
+                cols,
                 generators[0] if generators else None
             )
 
@@ -423,8 +424,8 @@ class DataFrameInternal:
         condition = parse(condition)
 
         def mapper(partition_index, partition):
-            initialized_condition = condition.initialize(partition_index)
-            return (row for row in partition if initialized_condition.eval(row, self.bound_schema))
+            condition.initialize(partition_index)
+            return (row for row in partition if condition.eval(row, self.bound_schema))
 
         return self._with_rdd(
             self._rdd.mapPartitionsWithIndex(mapper),

--- a/pysparkling/sql/types.py
+++ b/pysparkling/sql/types.py
@@ -26,7 +26,7 @@ import sys
 
 from sqlparser.internalparser import SqlParsingError
 
-from .utils import require_minimum_pandas_version, AnalysisException
+from .utils import AnalysisException, require_minimum_pandas_version
 
 __all__ = [
     "DataType", "NullType", "StringType", "BinaryType", "BooleanType", "DateType",
@@ -1144,20 +1144,19 @@ def merge_decimal_types(p1, s1, p2, s2, operation):
     if operation in ("add", "minus"):
         result_scale = max(s1, s2)
         return DecimalType.adjust_precision_scale(max(p1 - s1, p2 - s2) + result_scale + 1, result_scale)
-    elif operation == "multiply":
+    if operation == "multiply":
         return DecimalType.adjust_precision_scale(p1 + p2 + 1, s1 + s2)
-    elif operation == "divide":
+    if operation == "divide":
         result_scale = max(6, s1 + p2 + 1)
         return DecimalType.adjust_precision_scale(p1 - s1 + s2 + result_scale, result_scale)
-    elif operation == "mod":
+    if operation == "mod":
         result_scale = max(s1, s2)
         return DecimalType.adjust_precision_scale(min(p1 - s1, p2 - s2) + result_scale, result_scale)
-    elif operation in ("bitwise_or", "bitwise_and", "bitwise_xor"):
+    if operation in ("bitwise_or", "bitwise_and", "bitwise_xor"):
         if (p1, s1) != (p2, s2):
             raise AnalysisException("data type mismatch: differing types")
         return DecimalType.adjust_precision_scale(p1, s1)
-    else:
-        raise ValueError(f"Unknown operation {operation}")
+    raise ValueError(f"Unknown operation {operation}")
 
 
 def _need_converter(dataType):


### PR DESCRIPTION
Implement column data type handling

This is a prerequisite to support df.filter("a == 0") but reject "df.filter(2 + 2)", like spark does